### PR TITLE
Flip comparison operator in transactions.ts

### DIFF
--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -690,7 +690,7 @@ export const sendSignAndConfirmTransactions = async ({
         });
       }
     }
-    if (config.autoRetry && config.maxRetries < config.retried) {
+    if (config.autoRetry && config.maxRetries > config.retried) {
       const idx = (e as any)?.transactionInstructionIdx;
       if (typeof idx !== 'undefined') {
         config.retried++;


### PR DESCRIPTION
During an implementation I was noticing that retry logic was never executing. On closer inspection I found the operator for maxRetries was flipped the wrong direction. This PR flips the operator to look if maxRetries are greater than the number retried.